### PR TITLE
Corrected DFS Method

### DIFF
--- a/Graph.java
+++ b/Graph.java
@@ -161,32 +161,30 @@ public class Graph {
 		}
 	}
 
-	public void depthFirstSearch(int startingNode){
-		Stack<Integer> nodeQueue = new Stack<Integer>();		//queue where new un-visited nodes are stored
-		nodeQueue.add(startingNode);	//Initialize the queue with the starting node
-		//Array saying if a node has been visited. (INDEXED FROM 1, IGNORING 0). All future accesses must use an offset of +1 for "normal" arrays
-		boolean[] visitedNodes = new boolean[ getNodeCount() +1];		
-		ArrayList<Integer> nodesInVisitedOrder = new ArrayList<Integer>();	//list of nodes in the order that they are visited. Printed at the end of the algorithm
-		
-		while( !nodeQueue.isEmpty()){		//repeat the algorithm until queue is empty, like the pseudocaode says
-			int nodeRemovedFromQueue = nodeQueue.pop();		//pick a node from the head of the queue
-			
-			if( !visitedNodes[nodeRemovedFromQueue+1]){		//If NOT visited. (offset by +1 to make human readable array indexes)
-				visitedNodes[nodeRemovedFromQueue+1]=true;	//set to visited
-				nodesInVisitedOrder.add(nodeRemovedFromQueue);	//append to list of nodes in order they are visited
-				
-				LinkedList<Integer> rowOfNodes = getAdjacencyList().get(nodeRemovedFromQueue);	//get a list of all nodes adjacent to the current Node
-				ListIterator<Integer> iterator = rowOfNodes.listIterator();		//get an iterator for the row (using iterator since LinkedList)
-				while(iterator.hasNext()){			//Iterate over all nodes adjacent to the current node. The pseudocode has this as a FOR LOOP, but I use an Iterator & while loop since each row is a LinkedList
-					int nodeInColumn = iterator.next();
-					if( !visitedNodes[nodeInColumn+1]){		//if it's NOT visited, add to queue
-						nodeQueue.add(nodeInColumn);
-					}
-				}
-			}
-		}
-		System.out.println("\nDepth first search visitation order\n"+nodesInVisitedOrder);
-	}
+	public void depthFirstSearch(int startingNode) {
+        // create a boolean array to mark visited nodes
+        boolean[] visited = new boolean[validNodes.length + 1];
+        // mark the starting node as visited
+        visited[startingNode] = true;
+
+        System.out.println("Depth first search visitation order");
+        dfsHelper(startingNode, visited);
+        System.out.println();
+    }
+
+    private void dfsHelper(int currentNode, boolean[] visited) {
+        System.out.print(currentNode + " ");
+
+        // get the children of the current node
+        LinkedList<Integer> children = graphAdjacencyList.get(currentNode);
+        for (Integer child : children) {
+            // if the child has not been visited yet, mark it as visited and recursively call the helper method
+            if (!visited[child]) {
+                visited[child] = true;
+                dfsHelper(child, visited);
+            }
+        }
+    }
 	
 	@Override
 	public String toString() {


### PR DESCRIPTION
The DFS method in the original code doesn't transverse the nodes in a DFS manner, making the output incorrect. The original output when starting with node 2 is 
`Depth first search visitation order
[2, 5, 6, 4, 3, 8, 7, 1]`


It should be,
`[2, 1, 3, 5, 4, 6, 7, 8]`

The new implementation uses a helper method dfsHelper that recursively visits the children of a node, using the visited array to keep track of the visited nodes.

Here's a breakdown of the modified code:

1. The depthFirstSearch method takes in an integer startingNode as a parameter, which represents the node from where the traversal should start.
2. It creates a boolean array visited of the same length as the number of nodes in the graph. This array is used to keep track of the visited nodes.
3. It marks the starting node as visited by setting the corresponding element in the visited array to true.
4. It then calls the helper method dfsHelper and passes the starting node, and visited array as arguments
5. Inside the dfsHelper method, it first prints the current node, which represents the node that is currently being visited.
6. Then, it gets the children of the current node by accessing the corresponding element in the graphAdjacencyList.
7. It iterates through the children of the current node, and for each child, it checks if it has been visited yet by checking the corresponding element in the visited array.
8. If the child has not been visited yet, it marks it as visited by setting the corresponding element in the visited array to true, then it recursively calls the dfsHelper method and passes the child node as the current node, and the visited array.
9. The traversal continues in this manner, visiting all the children of a node before moving on to the next node, until all the nodes have been visited.

This implementation will correctly traverse the graph in a depth-first manner and will give the correct output of [2, 1, 3, 5, 4, 6, 7, 8] for a starting node of 2. Additionally, it uses the visited array to avoid revisiting the same node again.